### PR TITLE
Setting to remove logout text

### DIFF
--- a/javascripts/discourse/components/logout-header-button.gjs
+++ b/javascripts/discourse/components/logout-header-button.gjs
@@ -1,16 +1,30 @@
 import DButton from "discourse/components/d-button";
 import routeAction from "discourse/helpers/route-action";
 
-const LogoutHeaderButton = <template>
-  <li class="logout">
-    <DButton
-      @action={{routeAction "logout"}}
-      class="btn-flat icon"
-      @icon="sign-out-alt"
-      @title="user.log_out"
-      @label="user.log_out"
-    />
-  </li>
-</template>;
+let LogoutHeaderButton;
 
+if (settings.hide_log_out_text_in_header) {
+  LogoutHeaderButton = <template>
+    <li class="logout">
+      <DButton
+        @action={{routeAction "logout"}}
+        class="btn-flat icon"
+        @icon="sign-out-alt"
+        @title="user.log_out"
+      />
+    </li>
+  </template>;
+} else {
+  LogoutHeaderButton = <template>
+    <li class="logout">
+      <DButton
+        @action={{routeAction "logout"}}
+        class="btn-flat icon"
+        @icon="sign-out-alt"
+        @title="user.log_out"
+        @label="user.log_out"
+      />
+    </li>
+  </template>;
+}
 export default LogoutHeaderButton;

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,6 @@
+hide_log_out_text_in_header:
+  type: bool
+  default: false
+  description:
+    en:
+      "Remove the 'log out' text in the header next to the logout button."


### PR DESCRIPTION
This removes the text 'Log Out' in the header using a setting, `hide_log_out_text_in_header`.